### PR TITLE
do not require DIRECTIO in header

### DIFF
--- a/guppi/guppi.py
+++ b/guppi/guppi.py
@@ -100,7 +100,7 @@ class Guppi():
         assert hread == "END"+" "*77, "Not a GUPPI RAW format"
         if return_raw:
             raw_header += hread
-        if header['DIRECTIO']:
+        if header.get('DIRECTIO', False):
             remainder = nbytes_read % DIRECT_IO_SIZE
             to_seek = (DIRECT_IO_SIZE - remainder)%DIRECT_IO_SIZE
             tmp_direct_io = self.file.read(to_seek).decode('UTF-8')
@@ -197,7 +197,7 @@ class Guppi():
             self.data_reshaped = self.data.reshape(self.obsnchan,
                     self.nsamps_per_block, self.npol)
 
-        if header['DIRECTIO']:
+        if header.get('DIRECTIO', False):
             remainder = self.blocsize % DIRECT_IO_SIZE
             to_seek = (DIRECT_IO_SIZE - remainder)%DIRECT_IO_SIZE
             if to_seek:


### PR DESCRIPTION
I am trying to use [gr-teleskop](https://github.com/luigifcruz) with some GUPPI files of my own (generated with [gr-guppi](https://github.com/daniestevez/gr-guppi)). gr-teleskop uses `guppi` to read the GUPPI files. When doing this, I've found that the `Guppi` class fails if the GUPPI file does not contain the `DIRECTIO` keyword in the header.

This is a simple fix. If the `DIRECTIO` keyword is missing from the header, we assume that the file does not use DIRECTIO.

I am sending this PR against the cf16 branch, since that is the branch that gr-teleskope recommends to use, but the changes are not specific to the cf16 format. They could be cherry-picked in the main branch as well.